### PR TITLE
💥 Convert package to ESM

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Node CI
+
+on:
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macOS-latest]
+        node: [12.20.0, 14.13.1, 16.0.0]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node }}
+      uses: actions/setup-node@v2
+      with:
+        node-version: ${{ matrix.node }}
+    - name: Install dependencies
+      run: npm install
+    - name: Run tests
+      run: npm test

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
 /node_modules/
-/npm-debug.log

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,6 +1,4 @@
 /**
- * Compute the 128-bit MurmurHash3 of the supplied `key`. If the `key` is given as string it will be [encoded using the UTF8 encoding](https://github.com/LinusU/encode-utf8).
+ * Compute the 128-bit MurmurHash3 of the supplied `key`. If the `key` is given as a string it will be [encoded using the UTF8 encoding](https://github.com/LinusU/encode-utf8).
  */
-declare function murmur128 (key: ArrayBuffer | string): ArrayBuffer
-
-export = murmur128
+export default function murmur128 (key: ArrayBuffer | string): ArrayBuffer

--- a/index.js
+++ b/index.js
@@ -1,8 +1,7 @@
-var imul = require('imul')
-var fmix = require('fmix')
-var encodeUtf8 = require('encode-utf8')
+import encodeUtf8 from 'encode-utf8'
+import fmix from 'fmix'
 
-var C = new Uint32Array([
+const C = new Uint32Array([
   0x239b961b,
   0xab0e9789,
   0x38b34ae5,
@@ -14,57 +13,56 @@ function rotl (m, n) {
 }
 
 function body (key, hash) {
-  var blocks = (key.byteLength / 16) | 0
-  var view32 = new Uint32Array(key, 0, blocks * 4)
+  const blocks = (key.byteLength / 16) | 0
+  const view32 = new Uint32Array(key, 0, blocks * 4)
 
-  var k
-  for (var i = 0; i < blocks; i++) {
-    k = view32.subarray(i * 4, (i + 1) * 4)
+  for (let i = 0; i < blocks; i++) {
+    const k = view32.subarray(i * 4, (i + 1) * 4)
 
-    k[0] = imul(k[0], C[0])
+    k[0] = Math.imul(k[0], C[0])
     k[0] = rotl(k[0], 15)
-    k[0] = imul(k[0], C[1])
+    k[0] = Math.imul(k[0], C[1])
 
     hash[0] = (hash[0] ^ k[0])
     hash[0] = rotl(hash[0], 19)
     hash[0] = (hash[0] + hash[1])
-    hash[0] = imul(hash[0], 5) + 0x561ccd1b
+    hash[0] = Math.imul(hash[0], 5) + 0x561ccd1b
 
-    k[1] = imul(k[1], C[1])
+    k[1] = Math.imul(k[1], C[1])
     k[1] = rotl(k[1], 16)
-    k[1] = imul(k[1], C[2])
+    k[1] = Math.imul(k[1], C[2])
 
     hash[1] = (hash[1] ^ k[1])
     hash[1] = rotl(hash[1], 17)
     hash[1] = (hash[1] + hash[2])
-    hash[1] = imul(hash[1], 5) + 0x0bcaa747
+    hash[1] = Math.imul(hash[1], 5) + 0x0bcaa747
 
-    k[2] = imul(k[2], C[2])
+    k[2] = Math.imul(k[2], C[2])
     k[2] = rotl(k[2], 17)
-    k[2] = imul(k[2], C[3])
+    k[2] = Math.imul(k[2], C[3])
 
     hash[2] = (hash[2] ^ k[2])
     hash[2] = rotl(hash[2], 15)
     hash[2] = (hash[2] + hash[3])
-    hash[2] = imul(hash[2], 5) + 0x96cd1c35
+    hash[2] = Math.imul(hash[2], 5) + 0x96cd1c35
 
-    k[3] = imul(k[3], C[3])
+    k[3] = Math.imul(k[3], C[3])
     k[3] = rotl(k[3], 18)
-    k[3] = imul(k[3], C[0])
+    k[3] = Math.imul(k[3], C[0])
 
     hash[3] = (hash[3] ^ k[3])
     hash[3] = rotl(hash[3], 13)
     hash[3] = (hash[3] + hash[0])
-    hash[3] = imul(hash[3], 5) + 0x32ac3b17
+    hash[3] = Math.imul(hash[3], 5) + 0x32ac3b17
   }
 }
 
 function tail (key, hash) {
-  var blocks = (key.byteLength / 16) | 0
-  var reminder = (key.byteLength % 16)
+  const blocks = (key.byteLength / 16) | 0
+  const reminder = (key.byteLength % 16)
 
-  var k = new Uint32Array(4)
-  var tail = new Uint8Array(key, blocks * 16, reminder)
+  const k = new Uint32Array(4)
+  const tail = new Uint8Array(key, blocks * 16, reminder)
 
   switch (reminder) {
     case 15:
@@ -76,9 +74,9 @@ function tail (key, hash) {
     case 13:
       k[3] = (k[3] ^ (tail[12] << 0))
 
-      k[3] = imul(k[3], C[3])
+      k[3] = Math.imul(k[3], C[3])
       k[3] = rotl(k[3], 18)
-      k[3] = imul(k[3], C[0])
+      k[3] = Math.imul(k[3], C[0])
       hash[3] = (hash[3] ^ k[3])
       // fallthrough
     case 12:
@@ -93,9 +91,9 @@ function tail (key, hash) {
     case 9:
       k[2] = (k[2] ^ (tail[8] << 0))
 
-      k[2] = imul(k[2], C[2])
+      k[2] = Math.imul(k[2], C[2])
       k[2] = rotl(k[2], 17)
-      k[2] = imul(k[2], C[3])
+      k[2] = Math.imul(k[2], C[3])
       hash[2] = (hash[2] ^ k[2])
       // fallthrough
     case 8:
@@ -110,9 +108,9 @@ function tail (key, hash) {
     case 5:
       k[1] = (k[1] ^ (tail[4] << 0))
 
-      k[1] = imul(k[1], C[1])
+      k[1] = Math.imul(k[1], C[1])
       k[1] = rotl(k[1], 16)
-      k[1] = imul(k[1], C[2])
+      k[1] = Math.imul(k[1], C[2])
       hash[1] = (hash[1] ^ k[1])
       // fallthrough
     case 4:
@@ -127,9 +125,9 @@ function tail (key, hash) {
     case 1:
       k[0] = (k[0] ^ (tail[0] << 0))
 
-      k[0] = imul(k[0], C[0])
+      k[0] = Math.imul(k[0], C[0])
       k[0] = rotl(k[0], 15)
-      k[0] = imul(k[0], C[1])
+      k[0] = Math.imul(k[0], C[1])
       hash[0] = (hash[0] ^ k[0])
   }
 }
@@ -162,7 +160,7 @@ function finalize (key, hash) {
   hash[3] = (hash[3] + hash[0]) | 0
 }
 
-module.exports = function murmur (key, seed) {
+export default function murmur (key, seed) {
   seed = (seed ? (seed | 0) : 0)
 
   if (typeof key === 'string') {
@@ -173,7 +171,7 @@ module.exports = function murmur (key, seed) {
     throw new TypeError('Expected key to be ArrayBuffer or string')
   }
 
-  var hash = new Uint32Array([seed, seed, seed, seed])
+  const hash = new Uint32Array([seed, seed, seed, seed])
 
   body(key, hash)
   tail(key, hash)

--- a/package.json
+++ b/package.json
@@ -3,18 +3,20 @@
   "version": "0.2.1",
   "license": "MIT",
   "repository": "LinusU/murmur-128",
+  "type": "module",
+  "exports": "./index.js",
   "scripts": {
-    "test": "standard && node test"
+    "test": "standard && node test && ts-readme-generator --check"
   },
   "dependencies": {
-    "encode-utf8": "^1.0.2",
-    "fmix": "^0.1.0",
-    "imul": "^1.0.0"
+    "encode-utf8": "^2.0.0",
+    "fmix": "^1.0.0"
   },
   "devDependencies": {
     "arraybuffer-equal": "^1.0.4",
-    "hex-to-array-buffer": "^1.1.0",
-    "standard": "^14.3.1"
+    "hex-to-array-buffer": "^2.0.0",
+    "standard": "^16.0.3",
+    "ts-readme-generator": "^0.5.1"
   },
   "keywords": [
     "digest",
@@ -26,5 +28,8 @@
     "murmurhash",
     "murmurhash3",
     "quick"
-  ]
+  ],
+  "engines": {
+    "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+  }
 }

--- a/readme.md
+++ b/readme.md
@@ -11,7 +11,7 @@ npm install --save murmur-128
 ## Usage
 
 ```js
-const murmur128 = require('murmur-128')
+import murmur128 from 'murmur-128'
 
 murmur128('linus')
 //=> ArrayBuffer { 16 }
@@ -22,10 +22,12 @@ murmur128(new ArrayBuffer(10))
 
 ## API
 
-### murmur128(key: ArrayBuffer | string) => ArrayBuffer
+### `murmur128(key)`
 
-Compute the 128-bit MurmurHash3 of the supplied `key`. If the `key` is given as
-string it will be [encoded using the UTF8 encoding](https://github.com/LinusU/encode-utf8).
+- `key` (`ArrayBuffer | string`, required)
+- returns `ArrayBuffer`
+
+Compute the 128-bit MurmurHash3 of the supplied `key`. If the `key` is given as a string it will be [encoded using the UTF8 encoding](https://github.com/LinusU/encode-utf8).
 
 ## See also
 

--- a/test.js
+++ b/test.js
@@ -1,9 +1,9 @@
-var murmur = require('./')
-var assert = require('assert')
-var isEqual = require('arraybuffer-equal')
-var hexToArrayBuffer = require('hex-to-array-buffer')
+import assert from 'node:assert'
+import isEqual from 'arraybuffer-equal'
+import hexToArrayBuffer from 'hex-to-array-buffer'
+import murmur from './index.js'
 
-var testCases = [
+const testCases = [
   ['00000000000000000000000000000000', ''],
   ['30ef026f687d0c55687d0c55687d0c55', 'test'],
   ['f8c3526fe5bfe31be9c5ca68e9c5ca68', 'linus'],


### PR DESCRIPTION
Migration Guide:

This relases changes the package from a Common JS module to an EcmaScript module, and drops support for older versions of Node.

- The minimum version of Node.js supported is now: `12.20.0`, `14.13.1`, and `16.0.0`
- The package must now be imported using the native `import` syntax instead of with `require`